### PR TITLE
Dev 1514 revert ordering

### DIFF
--- a/src/main/scala/json/schema/parser/JsonSchemaDecoder.scala
+++ b/src/main/scala/json/schema/parser/JsonSchemaDecoder.scala
@@ -10,8 +10,6 @@ import scala.util.matching.Regex
 import scalaz.{IList, NonEmptyList}
 import json.schema.parser.JsonSchemaDecoder._
 
-import scala.collection.immutable.ListMap
-
 class JsonSchemaDecoder[N] protected (parentId: URI, rootSchema: Boolean)(implicit
     valueNumeric: Numeric[N],
     numberDecoder: DecodeJson[N]
@@ -94,7 +92,7 @@ class JsonSchemaDecoder[N] protected (parentId: URI, rootSchema: Boolean)(implic
       nestedDocumentDecoder: DecodeJson[Schema]
   ): DecodeResult[ObjectConstraint[N]] = {
     val mapOfSchemas = (c: HCursor, field: String) =>
-      c.get[Option[ListMap[String, Schema]]](field)(OptionDecodeJson(ListMapDecodeJson))
+      c.get[Option[Map[String, Schema]]](field)(OptionDecodeJson(MapDecodeJson))
     for {
       propsConstrain    <- rangeConstrain(c, "minProperties", "maxProperties")
       additionalProps   <- c.get[Option[Either[Boolean, Schema]]]("additionalProperties")
@@ -109,7 +107,7 @@ class JsonSchemaDecoder[N] protected (parentId: URI, rootSchema: Boolean)(implic
           _.fold[Option[Schema]](v => if (v) Some(SchemaDocument[N](scope)) else None, Option(_))
         ),
         ConstrainedMap(
-          properties.getOrElse(ListMap.empty).map {
+          properties.getOrElse(Map.empty).map {
             case (name, schema) => name -> Property(requiredField.contains(name), schema)
           },
           propsConstrain

--- a/src/main/scala/json/schema/parser/model.scala
+++ b/src/main/scala/json/schema/parser/model.scala
@@ -3,11 +3,9 @@ package json.schema.parser
 import java.net.URI
 
 import argonaut.Json
+import scalaz.IList
 
 import scala.util.matching.Regex
-import scalaz.{IList, NonEmptyList}
-
-import scala.collection.immutable.ListMap
 
 object SimpleType extends Enumeration {
   type SimpleType = Value
@@ -48,7 +46,7 @@ case class RangeConstrain[T](max: Option[T] = None, min: Option[T] = None)
 
 case class ConstrainedList[T](value: IList[T], sizeConstrain: RangeConstrain[Inclusive[Int]])
 
-case class ConstrainedMap[T](value: ListMap[String, T], sizeConstrain: RangeConstrain[Inclusive[Int]])
+case class ConstrainedMap[T](value: Map[String, T], sizeConstrain: RangeConstrain[Inclusive[Int]])
 
 case class Property[N](required: Boolean, schema: SchemaDocument[N])
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.13.1-SNAPSHOT"
+version in ThisBuild := "0.13.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.13.1"
+version in ThisBuild := "0.13.2-SNAPSHOT"


### PR DESCRIPTION
use the map, otherwise the casecodec implicit are generated in a different order